### PR TITLE
removed mediaRepository from product-detail-override

### DIFF
--- a/src/Resources/app/administration/src/module/sas-esd/page/sw-product-detail/index.js
+++ b/src/Resources/app/administration/src/module/sas-esd/page/sw-product-detail/index.js
@@ -46,10 +46,6 @@ Component.override('sw-product-detail', {
             'isLoading'
         ]),
 
-        mediaRepository() {
-            return this.repositoryFactory.create('media');
-        },
-
         esdMediaRepository() {
             return this.repositoryFactory.create('sas_product_esd_media');
         },


### PR DESCRIPTION
Hi,

currently you override the mediaRepository in the override of the product-detailed-page module. This leads to errors if you try to add a media to a product in the administration since 6.3.4.1.
To Recreate the error:
Admin -> Product Detail Page -> Media -> Add Media from media Sidebar -> Error "Please fill in all Fields"
