### PR TITLE
Enable Discount

### DIFF
--- a/src/Service/EsdOrderService.php
+++ b/src/Service/EsdOrderService.php
@@ -211,6 +211,9 @@ class EsdOrderService
     public function isEsdOrder(OrderEntity $order): bool
     {
         foreach ($order->getLineItems() as $lineItem) {
+            if (!$lineItem->getProduct()) {
+                continue;
+            }
             /** @var EsdEntity $esd */
             $esd = $lineItem->getProduct()->getExtension('esd');
             if (empty($esd)) {


### PR DESCRIPTION
In the newest version of this plugin this part also needs to skip the line items without products. In general: shopware always insert discounts as line items w/o products assigned.