### PR TITLE
fix fileAccept to accept all filetypes

### DIFF
--- a/src/Resources/app/administration/src/module/sas-esd/component/sas-media-upload/index.js
+++ b/src/Resources/app/administration/src/module/sas-esd/component/sas-media-upload/index.js
@@ -7,7 +7,7 @@ Shopware.Component.extend('sas-media-upload', 'sw-media-upload-v2', {
         fileAccept: {
             type: String,
             required: false,
-            default: 'image/*'
+            default: '*/*'
         }
 
     },

--- a/src/Resources/app/administration/src/module/sas-esd/view/sas-product-detail-esd/index.js
+++ b/src/Resources/app/administration/src/module/sas-esd/view/sas-product-detail-esd/index.js
@@ -17,7 +17,7 @@ Component.register('sas-product-detail-esd', {
     data() {
         return {
             activeModal: '',
-            fileAccept: '*',
+            fileAccept: '*/*',
             selectedItems: null,
             isLoading: true,
             isLoadedEsd: false,


### PR DESCRIPTION
The setting `fileAccept: '*'` doesn't allow e.g. `application/pdf` to be uploaded as ESD in the product detail administration.
administration-js has to be rebuild before publishing to new version!