### PR TITLE
fix: replace mime-types with inline lookup to fix esbuild build

### DIFF
--- a/src/Resources/app/administration/package.json
+++ b/src/Resources/app/administration/package.json
@@ -11,7 +11,6 @@
   "license": "ISC",
   "dependencies": {
     "lodash": "^4.17.19",
-    "mime-types": "^2.1.24",
     "papaparse": "^5.0.0"
   },
   "devDependencies": {

--- a/src/Resources/app/administration/src/module/sas-esd/component/sas-esd-modal-csv/index.js
+++ b/src/Resources/app/administration/src/module/sas-esd/component/sas-esd-modal-csv/index.js
@@ -1,6 +1,15 @@
 import { drop, every, forEach, get, isArray, map, set } from 'lodash';
 import Papa from 'papaparse';
-import mimeTypes from 'mime-types';
+
+const lookupMimeType = (fileName) => {
+    const ext = fileName.split('.').pop().toLowerCase();
+    const map = {
+        csv: 'text/csv',
+        txt: 'text/plain',
+        xls: 'application/vnd.ms-excel',
+    };
+    return map[ext] || false;
+};
 
 import template from './sas-esd-modal-csv.html.twig';
 
@@ -193,7 +202,7 @@ export default {
         },
         validFileMimeType() {
             const file = this.$refs.csv.files[0];
-            const mimeType = file.type === '' ? mimeTypes.lookup(file.name) : file.type;
+            const mimeType = file.type === '' ? lookupMimeType(file.name) : file.type;
             if (file) {
                 this.fileSelected = true;
                 this.isValidFileMimeType = this.validation ? this.validateMimeType(mimeType) : true;


### PR DESCRIPTION
The mime-types npm package uses Node's built-in 'path' module which esbuild cannot bundle for the browser environment, causing the store upload pipeline to fail.

Replaced mime-types.lookup() with a small inline function covering the file extensions accepted by the CSV import validation.