### PR TITLE
4.0.2 - Fix 500 error on /checkout/cart.json

### DIFF
--- a/CHANGELOG_de-DE.md
+++ b/CHANGELOG_de-DE.md
@@ -1,3 +1,6 @@
+# 4.0.2
+- 500-Fehler bei /checkout/cart.json (AJAX-Anfragen des Off-Canvas-Warenkorbs) behoben, verursacht durch fehlende cartJson-Methode im Checkout-Controller-Decorator
+
 # 4.0.1
 - Absturz beim Hinzufügen eines ESD-Produkts mit unzureichenden Seriennummern zum Warenkorb behoben
 - Warenkorb-Validierung hinzugefügt, um das Hinzufügen von mehr Artikeln als verfügbare Seriennummern zu verhindern

--- a/CHANGELOG_en-GB.md
+++ b/CHANGELOG_en-GB.md
@@ -1,3 +1,6 @@
+# 4.0.2
+- Fixed 500 error on /checkout/cart.json (off-canvas cart AJAX requests) caused by missing cartJson method in the checkout controller decorator
+
 # 4.0.1
 - Fixed crash when adding ESD product with insufficient serial numbers to cart
 - Added cart validation to prevent adding more items than available serial numbers

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description":"ESD / Download plugin",
     "type":"shopware-platform-plugin",
     "keywords": ["esd", "download"],
-    "version":"4.0.1",
+    "version":"4.0.2",
     "license":"proprietary",
     "authors":[
         {

--- a/src/Storefront/Controller/CheckoutControllerDecorator.php
+++ b/src/Storefront/Controller/CheckoutControllerDecorator.php
@@ -28,6 +28,11 @@ class CheckoutControllerDecorator extends StorefrontController
         return $this->decoratedController->cartPage($request, $context);
     }
 
+    public function cartJson(Request $request, SalesChannelContext $context): Response
+    {
+        return $this->decoratedController->cartJson($request, $context);
+    }
+
     public function confirmPage(Request $request, SalesChannelContext $context): Response
     {
         return $this->decoratedController->confirmPage($request, $context);


### PR DESCRIPTION
## Summary
- Fixes a customer-reported 500 Internal Server Error on `/checkout/cart.json` (`frontend.checkout.cart.json`), which broke off-canvas/mini-cart AJAX updates on the storefront.
- Root cause: `CheckoutControllerDecorator` decorates the core `CheckoutController` but did not delegate the `cartJson` method that Shopware core dispatches for that route, so the request hit a missing method.
- Adds the `cartJson` pass-through to the decorator. Compared against all public methods of the core 6.7 `CheckoutController` — this was the only one missing.
- Bumps version to 4.0.2 and updates both changelogs.

## Testing
- Verified in a local Shopware 6.7 (ddev) environment: `GET /checkout/cart.json` returned 500 before the fix and now returns 200 with the cart JSON payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzRfHxiP6vikLazmuAhp5Y

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 500 error on `/checkout/cart.json` by adding `cartJson` to `CheckoutControllerDecorator`
> The `cartJson` method was missing from [CheckoutControllerDecorator.php](https://github.com/Shape-and-Shift/shopware-esd/pull/102/files#diff-307504aa1a9b3a317ac5a9db90e23a3b3ba989569e7cc8fde8ba203469ad476e), causing a 500 error on the `/checkout/cart.json` endpoint. The fix adds a passthrough method that delegates `(Request $request, SalesChannelContext $context)` to the decorated `CheckoutController`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46fe60b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a 500 error when loading cart data through `/checkout/cart.json`.
  * Restored cart functionality for off-canvas cart AJAX requests.

* **Release**
  * Updated the plugin version to 4.0.2.
  * Added release notes in English and German.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->